### PR TITLE
v2.0.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,9 @@
 name: CI
 on:
   push:
-    branches: [main]
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 jobs:
   test:
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node: [10, 12, 14, 15]
+        node: [12, 14, 15]
         os:
         - ubuntu-latest
         - macos-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node: [12.20, 14, 15]
+        node: ['12.20', '14.x', '15.x']
         os:
         - ubuntu-latest
         - macos-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node: [12, 14, 15]
+        node: [12.20, 14, 15]
         os:
         - ubuntu-latest
         - macos-latest

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,11 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
-      with:
-        node-version: '12'
-        registry-url: 'https://registry.npmjs.org'
-    - run: npm install
     - run: npm publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - run: npm publish
+    - run: |
+        npm install
+        npm publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -9,17 +9,16 @@ has different words for each power of 1000.
 Supports positive integers from 0 to Number.MAX_SAFE_INTEGER (9,007,199,254,740,991).  
 Larger values return "(big number)".
 
-## Example node.js
+### Example using node.js
 ```js
 import { shortscale } from 'shortscale';
 
-// four hundred and twenty billion nine hundred and ninety nine thousand and fifteen
 console.log(shortscale(420000999015));
+// four hundred and twenty billion nine hundred and ninety nine thousand and fifteen
 ```
 
-## ESM
 This library is packaged as an ESM module.  
 For CommonJS packaging please point to version `^1.1.0` in your package.json.
 
-## Rust
+### Rust
 For Rust version see [jldec/shortscale-rs](https://github.com/jldec/shortscale-rs).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,17 @@ has different words for each power of 1000.
 Supports positive integers from 0 to Number.MAX_SAFE_INTEGER (9,007,199,254,740,991).  
 Larger values return "(big number)".
 
-E.g. `shortscale(420000999015)` returns  
-`"four hundred and twenty billion nine hundred and ninety nine thousand and fifteen"`
+## Example node.js
+```js
+import { shortscale } from 'shortscale';
 
+// four hundred and twenty billion nine hundred and ninety nine thousand and fifteen
+console.log(shortscale(420000999015));
+```
+
+## ESM
+This library is packaged as an ESM module.  
+For CommonJS packaging please point to version `^1.1.0` in your package.json.
+
+## Rust
 For Rust version see [jldec/shortscale-rs](https://github.com/jldec/shortscale-rs).

--- a/example/.npmrc
+++ b/example/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,12 @@
+# shortscale example (using node.js)
+
+To run this example:
+
+```
+$ npm install
+```
+
+```
+$ node example
+four hundred and twenty billion nine hundred and ninety nine thousand and fifteen
+```

--- a/example/example.js
+++ b/example/example.js
@@ -1,0 +1,4 @@
+import { shortscale } from 'shortscale';
+
+// four hundred and twenty billion nine hundred and ninety nine thousand and fifteen
+console.log(shortscale(420000999015));

--- a/example/package.json
+++ b/example/package.json
@@ -1,0 +1,7 @@
+{
+  "main": "example.js",
+  "type": "module",
+  "dependencies": {
+    "shortscale": "2.x"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "shortscale.js",
   "type": "module",
   "scripts": {
-    "test": "node test/test-*.js",
+    "test": "node test/test-shortscale.js",
     "bench": "node test/bench.js"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "shortscale",
-  "version": "1.1.0",
-  "description": "Convert positive integers to English words",
+  "version": "2.0.0",
+  "description": "Convert positive integers to English words (ESM only)",
   "main": "shortscale.js",
+  "type": "module",
   "scripts": {
-    "test": "tape test/test-*.js",
+    "test": "node test/test-*.js",
     "bench": "node test/bench.js"
   },
   "files": [
@@ -18,10 +19,13 @@
   "author": "Jürgen Leschner",
   "license": "MIT",
   "devDependencies": {
-    "tape": "^5.0.1"
+    "tape": "^5.1.1"
   },
   "repository": {
     "type": "git",
     "url": "git://github.com/jldec/shortscale.git"
+  },
+  "engines": {
+    "node": ">=12.17.0"
   }
 }

--- a/shortscale.js
+++ b/shortscale.js
@@ -51,7 +51,18 @@ const numwords = {
   1000000000000000: 'quadrillion'
 };
 
-module.exports = function shortscale(num) {
+export default shortscale;
+
+/**
+ * Return a string of English words for a number.
+ *
+ * Supports positive integers from 0 to Number.MAX_SAFE_INTEGER
+ * i.e. 0 to 9,007,199,254,740,991
+
+ * @param {number} num
+ * @returns {string}
+ */
+export function shortscale(num) {
   if (num === 0) return 'zero';
   if (num > Number.MAX_SAFE_INTEGER) return '(big number)';
 

--- a/test/bench.js
+++ b/test/bench.js
@@ -1,4 +1,4 @@
-const shortscale = require('../shortscale.js');
+import { shortscale } from '../shortscale.js';
 
 const RUNS = 15
 const ITERATIONS = 20000;

--- a/test/test-shortscale.js
+++ b/test/test-shortscale.js
@@ -1,6 +1,6 @@
-const test = require('tape');
+import test from 'tape';
 
-const shortscale = require('../shortscale.js');
+import { shortscale } from '../shortscale.js';
 
 const tests = [
   [0, 'zero'],


### PR DESCRIPTION
- publish as ESM instead of CJS module
- requires node v12.17 or later
- converted tests and bench to ESM
- added example
- simplified publish action